### PR TITLE
Participant view for realtime events

### DIFF
--- a/database/functions.sql
+++ b/database/functions.sql
@@ -80,12 +80,12 @@ declare
   main_user_registration bigint;
   other_user_group bigint;
   other_user_registration bigint;
-  event_id bigint;
+  _event_id bigint;
   event_group bigint;
 begin
-  select into event_id, event_group events.id, events.event_group_pair from events where events.id in (select event_id from event_rounds where event_rounds.id = event_round);
-  select into main_user_group, main_user_registration reg.group, reg.id from event_registrations as reg where reg.user_id = main_user and reg.event_id = event_id;
-  select into other_user_group, other_user_registration reg.group, reg.id from event_registrations as reg where reg.user_id = other_user and reg.event_id = event_id;
+  select into _event_id, event_group events.id, events.event_group_pair from events where events.id in (select event_id from event_rounds where event_rounds.id = event_round);
+  select into main_user_group, main_user_registration reg.group_id, reg.id from event_registrations as reg where reg.user_id = main_user and reg.event_id = _event_id;
+  select into other_user_group, other_user_registration reg.group_id, reg.id from event_registrations as reg where reg.user_id = other_user and reg.event_id = _event_id;
 
   if (main_user_registration is null or other_user_registration is null) then -- on of the users is not registered
     return false;

--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -9,6 +9,7 @@ declare module "@vue/runtime-core" {
   export interface GlobalComponents {
     AboutPage: typeof import("./components/pages/AboutPage.vue")["default"];
     Countdown: typeof import("./components/Countdown.vue")["default"];
+    CurrentParticipantEventPage: typeof import("./components/pages/CurrentParticipantEventPage.vue")["default"];
     EditEvent: typeof import("./components/EditEvent.vue")["default"];
     EventCreatePage: typeof import("./components/pages/EventCreatePage.vue")["default"];
     EventDashboard: typeof import("./components/pages/EventDashboard.vue")["default"];

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -224,6 +224,11 @@ onMounted(async () => {
     if (ongoingRound !== null) {
       currentRoundId.value = ongoingRound.id;
       roundOngoing.value = true;
+      const currentPair = await currentEvent.getCurrentPair();
+      console.log(currentPair);
+      if (currentPair !== null) {
+        currentPairId.value = currentPair.id;
+      }
       setupTimer(ongoingRound);
     }
   }

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -150,11 +150,18 @@ const setupTimer = (round: definitions["event_rounds"]) => {
   countingInterval.value = startCountdown();
 };
 
-const vote = (match: boolean) => {
-  hasVoted.value = true;
-  // clear round specific variables
-  currentPairId.value = undefined;
-  currentRoundId.value = undefined;
+const vote = async (match: boolean) => {
+  if (!currentPairId.value) return;
+  try {
+    await currentEvent.vote(currentPairId.value, match);
+    hasVoted.value = true;
+    // clear round specific variables
+    currentPairId.value = undefined;
+    currentRoundId.value = undefined;
+  } catch (e) {
+    console.log(e);
+    errorToast(e);
+  }
 };
 
 const createPair = async () => {

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -1,16 +1,64 @@
 <template>
   <v-main>
     <v-container class="h-100">
-      <div class="h-50 d-flex flex-column align center justify-center pl-2">
+      <div
+        v-if="!eventStarted"
+        class="h-50 d-flex flex-column align center justify-center pl-2"
+      >
         <span class="d-flex font-weight-medium text-h6"
           >The event hasn't started yet...</span
         >
         <span class="d-block text-subtitle-2"
-          >Please wait for the host to start the event</span
+          >Please wait for the organizer to start the event</span
         >
       </div>
+      <div v-else>Event started</div>
     </v-container>
   </v-main>
 </template>
 
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import router from "@/router";
+import { supabase } from "@/services/supabase";
+import { useCurrentEventStore } from "@/stores/currentEvent";
+import type { RealtimeSubscription } from "@supabase/realtime-js";
+
+const currentEvent = useCurrentEventStore();
+
+const eventSubscription = ref<RealtimeSubscription>();
+
+const eventStarted = ref(false);
+
+onMounted(async () => {
+  if (!currentEvent.hasEvent) {
+    errorToast(
+      "This event does not exist or you have not confirmed you're present"
+    );
+    router.push("/");
+    return;
+  }
+  const eventId = +currentEvent.getCurrentId();
+  // Generated types do not work with the realtime syntax
+  eventSubscription.value = supabase
+    .from<any>("events:id=eq." + eventId)
+    .on("UPDATE", (payload) => {
+      if (payload.new.is_started) eventStarted.value = true;
+    })
+    .subscribe();
+  const event = await currentEvent.getCurrentEvent();
+  if (event === null) {
+    errorToast(
+      "This event does not exist or you have not confirmed you're present"
+    );
+    router.push("/");
+    return;
+  }
+  if (event.is_started) {
+    eventStarted.value = true;
+  }
+});
+
+onBeforeUnmount(() => {
+  eventSubscription.value?.unsubscribe();
+});
+</script>

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -42,6 +42,7 @@ watch(
         currentRoundId.value = payload.new.id;
       })
       .subscribe();
+    console.log("round subscription activated");
   }
 );
 
@@ -80,5 +81,6 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   eventSubscription.value?.unsubscribe();
+  roundSubscription.value?.unsubscribe();
 });
 </script>

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -27,9 +27,11 @@ const currentEvent = useCurrentEventStore();
 
 const eventSubscription = ref<RealtimeSubscription>();
 const roundSubscription = ref<RealtimeSubscription>();
+const pairSubscription = ref<RealtimeSubscription>();
 
 const eventStarted = ref(false);
 const currentRoundId = ref<number>();
+const currentPairId = ref<number>();
 
 watch(
   () => eventStarted.value,
@@ -43,6 +45,13 @@ watch(
       })
       .subscribe();
     console.log("round subscription activated");
+    pairSubscription.value = supabase
+      .from("event_user_pairs")
+      .on("INSERT", (payload) => {
+        currentPairId.value = payload.new.id;
+      })
+      .subscribe();
+    console.log("pair subscription activiated");
   }
 );
 
@@ -82,5 +91,6 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   eventSubscription.value?.unsubscribe();
   roundSubscription.value?.unsubscribe();
+  pairSubscription.value?.unsubscribe();
 });
 </script>

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -1,8 +1,17 @@
 <template>
   <v-main>
     <v-container class="h-100 pt-12">
-      <div class="h-100 d-flex justify-center align-center" v-if="eventEnded">
-        <span class="d-block">That's all volks!</span>
+      <div
+        class="h-75 d-flex flex-column justify-center align-center"
+        v-if="eventEnded"
+      >
+        <span class="d-block text-h4 font-weight-bold">That's all volks!</span>
+        <span class="d-block"
+          >This event is now over, thanks for being here!</span
+        >
+        <v-btn class="mt-16" color="primary" to="/" variant="text"
+          >To Homepage</v-btn
+        >
       </div>
       <div
         v-else-if="!eventStarted"

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-main>
-    <v-container class="h-100">
+    <v-container class="h-100 pt-12">
       <div
         v-if="!eventStarted"
         class="h-50 d-flex flex-column align center justify-center pl-2"
@@ -12,10 +12,31 @@
           >Please wait for the organizer to start the event</span
         >
       </div>
-      <div class="h-100 d-flex justify-center align-center" v-if="eventEnded">
+      <div
+        class="h-100 d-flex justify-center align-center"
+        v-else-if="eventEnded"
+      >
         <span class="d-block">That's all volks!</span>
       </div>
-      <div v-else-if="roundOngoing">Current Round ID: {{ currentRoundId }}</div>
+      <div v-else-if="roundOngoing && !currentPairId">
+        <span class="d-block text-body-1 font-weight-bold"
+          >Let's find you a partner for this round!
+        </span>
+        <span class="d-block mb-4 text-body-2"
+          >Use the Qr-Scanner below or type their id in the textbox</span
+        >
+        <div
+          :style="{ width: '250px', height: '250px' }"
+          class="bg-grey mx-auto"
+        >
+          <span class="text-white">Nice Qr-Code scanner</span>
+        </div>
+        <v-text-field v-model="otherUser" label="ID (optional)">
+          <template v-slot:append>
+            <v-btn @click="createPair" color="secondary">Pair</v-btn>
+          </template>
+        </v-text-field>
+      </div>
       <div v-else>Waiting for new round...</div>
     </v-container>
   </v-main>
@@ -38,6 +59,19 @@ const eventEnded = ref(false);
 const roundOngoing = ref(false);
 const currentRoundId = ref<number>();
 const currentPairId = ref<number>();
+
+const otherUser = ref("");
+
+const createPair = async () => {
+  if (!currentRoundId.value) return;
+  try {
+    await currentEvent.createPair(otherUser.value, currentRoundId.value);
+    successToast;
+  } catch (e) {
+    console.log(e);
+    errorToast(e);
+  }
+};
 
 watch(
   () => eventStarted.value,

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -5,35 +5,38 @@
         class="h-75 d-flex flex-column justify-center align-center"
         v-if="eventEnded"
       >
-        <span class="d-block text-h4 font-weight-bold">That's all volks!</span>
-        <span class="d-block"
-          >This event is now over, thanks for being here!</span
-        >
-        <v-btn class="mt-16" color="primary" to="/" variant="text"
-          >To Homepage</v-btn
-        >
+        <span class="d-block text-h4 font-weight-bold">{{
+          t("pages.participant-event.ended-title")
+        }}</span>
+        <span class="d-block">{{
+          t("pages.participant-event.ended-subtitle")
+        }}</span>
+        <v-btn class="mt-16" color="primary" to="/" variant="text">{{
+          t("pages.participant-event.ended-button-link")
+        }}</v-btn>
       </div>
       <div
         v-else-if="!eventStarted"
         class="h-50 d-flex flex-column align center justify-center pl-2"
       >
-        <span class="d-flex font-weight-medium text-h6"
-          >The event hasn't started yet...</span
-        >
-        <span class="d-block text-subtitle-2"
-          >Please wait for the organizer to start the event</span
-        >
+        <span class="d-flex font-weight-medium text-h6">{{
+          t("pages.participant-event.not-started-title")
+        }}</span>
+        <span class="d-block text-subtitle-2">{{
+          t("pages.participant-event.not-started-subtitle")
+        }}</span>
       </div>
 
       <div v-else-if="roundOngoing && !currentPairId">
         <span class="d-block text-body-1 font-weight-bold"
-          >Let's find you a partner for this round!
+          >{{ t("pages.participant-event.searching-title") }}
         </span>
+        <span class="d-block mb-4 text-body-2">{{
+          t("pages.participant-event.searching-subtitle")
+        }}</span>
         <span class="d-block mb-4 text-body-2"
-          >Use the Qr-Scanner below or type their id in the textbox</span
-        >
-        <span class="d-block mb-4 text-body-2"
-          >{{ displayTime }} minutes left</span
+          >{{ displayTime }}
+          {{ t("pages.participant-event.searching-minutes-left") }}</span
         >
         <div
           :style="{ width: '250px', height: '250px' }"
@@ -43,7 +46,9 @@
         </div>
         <v-text-field v-model="otherUser" label="ID (optional)">
           <template v-slot:append>
-            <v-btn @click="createPair" color="secondary">Pair</v-btn>
+            <v-btn @click="createPair" color="secondary">{{
+              t("pages.participant-event.searching-manual-pair-button")
+            }}</v-btn>
           </template>
         </v-text-field>
       </div>
@@ -51,9 +56,9 @@
         class="h-75 d-flex flex-column justify-center align-center"
         v-else-if="roundOngoing"
       >
-        <span class="d-block text-h5 font-weight-bold mb-10"
-          >Have fun, you two!</span
-        >
+        <span class="d-block text-h5 font-weight-bold mb-10">{{
+          t("pages.participant-event.ongoing-title")
+        }}</span>
         <time-display
           v-if="roundDuration && roundTime"
           :max="roundDuration"
@@ -65,10 +70,12 @@
         v-else-if="!hasVoted && currentPairId"
       >
         <div class="pt-6">
-          <span class="d-block text-h4 pl-4">Did you like them?</span>
-          <span class="d-block pl-4 mb-12 text-grey-darken-1"
-            >Your partner will not see your decision immediately</span
-          >
+          <span class="d-block text-h4 pl-4">{{
+            t("pages.participant-event.vote-title")
+          }}</span>
+          <span class="d-block pl-4 mb-12 text-grey-darken-1">{{
+            t("pages.participant-event.vote-subtitle")
+          }}</span>
           <div class="d-flex justify-space-between px-6 bg-grey-lighten-3">
             <v-btn
               size="x-large"
@@ -87,9 +94,9 @@
         </div>
       </div>
       <div v-else class="h-75 d-flex flex-column justify-center align-center">
-        <span class="d-block text-h5 font-weight-bold mb-4"
-          >Waiting for new round</span
-        >
+        <span class="d-block text-h5 font-weight-bold mb-4">{{
+          t("pages.participant-event.waiting-title")
+        }}</span>
         <v-progress-circular class="text-h3" indeterminate size="100"
           >🐱</v-progress-circular
         >
@@ -105,8 +112,10 @@ import type { definitions } from "@/services/supabase-types";
 import { useCurrentEventStore } from "@/stores/currentEvent";
 import { Temporal } from "@js-temporal/polyfill";
 import type { RealtimeSubscription } from "@supabase/realtime-js";
+import { useI18n } from "vue-i18n";
 
 const currentEvent = useCurrentEventStore();
+const { t } = useI18n();
 
 const eventSubscription = ref<RealtimeSubscription>();
 const roundSubscription = ref<RealtimeSubscription>();

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -48,9 +48,12 @@
         </v-text-field>
       </div>
       <div
-        class="h-75 d-flex justify-center align-center"
+        class="h-75 d-flex flex-column justify-center align-center"
         v-else-if="roundOngoing"
       >
+        <span class="d-block text-h5 font-weight-bold mb-10"
+          >Have fun, you two!</span
+        >
         <time-display
           v-if="roundDuration && roundTime"
           :max="roundDuration"
@@ -83,7 +86,14 @@
           </div>
         </div>
       </div>
-      <div v-else>Waiting for new round...</div>
+      <div v-else class="h-75 d-flex flex-column justify-center align-center">
+        <span class="d-block text-h5 font-weight-bold mb-4"
+          >Waiting for new round</span
+        >
+        <v-progress-circular class="text-h3" indeterminate size="100"
+          >🐱</v-progress-circular
+        >
+      </div>
     </v-container>
   </v-main>
 </template>
@@ -193,6 +203,8 @@ watch(
         setupTimer(payload.new);
         currentRoundId.value = payload.new.id;
         roundOngoing.value = true;
+        // clear pairId of last round
+        currentPairId.value = undefined;
         hasVoted.value = false;
       })
       .subscribe();

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-main>
+    <v-container class="h-100">
+      <div class="h-50 d-flex flex-column align center justify-center pl-2">
+        <span class="d-flex font-weight-medium text-h6"
+          >The event hasn't started yet...</span
+        >
+        <span class="d-block text-subtitle-2"
+          >Please wait for the host to start the event</span
+        >
+      </div>
+    </v-container>
+  </v-main>
+</template>
+
+<script lang="ts" setup></script>

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -12,7 +12,11 @@
           >Please wait for the organizer to start the event</span
         >
       </div>
-      <div v-else>Current Round ID: {{ currentRoundId }}</div>
+      <div class="h-100 d-flex justify-center align-center" v-if="eventEnded">
+        <span class="d-block">That's all volks!</span>
+      </div>
+      <div v-else-if="roundOngoing">Current Round ID: {{ currentRoundId }}</div>
+      <div v-else>Waiting for new round...</div>
     </v-container>
   </v-main>
 </template>
@@ -30,6 +34,8 @@ const roundSubscription = ref<RealtimeSubscription>();
 const pairSubscription = ref<RealtimeSubscription>();
 
 const eventStarted = ref(false);
+const eventEnded = ref(false);
+const roundOngoing = ref(false);
 const currentRoundId = ref<number>();
 const currentPairId = ref<number>();
 
@@ -42,6 +48,7 @@ watch(
         // round of some other event we do not care about
         if (payload.new.event_id !== +currentEvent.getCurrentId()) return;
         currentRoundId.value = payload.new.id;
+        roundOngoing.value = true;
       })
       .subscribe();
     console.log("round subscription activated");
@@ -69,6 +76,7 @@ onMounted(async () => {
     .from<any>("events:id=eq." + eventId)
     .on("UPDATE", (payload) => {
       if (payload.new.is_started) eventStarted.value = true;
+      if (payload.new.is_ended) eventEnded.value = true;
     })
     .subscribe();
   const event = await currentEvent.getCurrentEvent();
@@ -84,6 +92,7 @@ onMounted(async () => {
     const ongoingRound = await currentEvent.getCurrentRound();
     if (ongoingRound !== null) {
       currentRoundId.value = ongoingRound.id;
+      roundOngoing.value = true;
     }
   }
 });

--- a/frontend/src/components/pages/CurrentParticipantEventPage.vue
+++ b/frontend/src/components/pages/CurrentParticipantEventPage.vue
@@ -131,6 +131,7 @@ watch(
         if (payload.new.event_id !== +currentEvent.getCurrentId()) return;
         currentRoundId.value = payload.new.id;
         roundOngoing.value = true;
+        setupTimer(payload.new);
       })
       .subscribe();
     console.log("round subscription activated");

--- a/frontend/src/components/pages/EventDashboard.vue
+++ b/frontend/src/components/pages/EventDashboard.vue
@@ -1,4 +1,7 @@
 <template>
+  <teleport to="#nav-right">
+    <v-btn icon="mdi-close-octagon" variant="text" @click="endEvent"></v-btn>
+  </teleport>
   <v-main>
     <v-container>
       <div class="bg-grey mb-6" :style="{ height: '100px' }"></div>
@@ -36,6 +39,7 @@ import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
 const currentEvent = useCurrentEventStore();
+const router = useRouter();
 
 const second = 1000;
 const minute = 60 * second;
@@ -91,6 +95,17 @@ const startRound = async () => {
   const round = await currentEvent.startNewRound(setDuration.value);
   setupTimer(round);
   startingRound.value = false;
+};
+
+const endEvent = async () => {
+  try {
+    await currentEvent.endCurrentEvent();
+    successToast("Event ended");
+    router.push("/");
+  } catch (e) {
+    console.log(e);
+    errorToast(e);
+  }
 };
 
 onMounted(async () => {

--- a/frontend/src/components/pages/HomePage.vue
+++ b/frontend/src/components/pages/HomePage.vue
@@ -17,14 +17,23 @@
         :key="i"
         :matchy-event="e"
         show-image
+        :pulse="e.id == +currentEventStore.getCurrentId()"
         :to="'/events/' + e.id"
         @share="share(e)"
       >
         <v-card-actions class="d-flex justify-center mh-0">
           <v-btn
+            v-if="e.id == +currentEventStore.getCurrentId()"
+            :to="'/events/' + e.id + '/participant'"
             color="primary"
             size="small"
-            @click.prevent="confirmPresence"
+            >To action</v-btn
+          >
+          <v-btn
+            v-else
+            color="primary"
+            size="small"
+            @click.prevent="confirmPresence(e.id)"
             >{{ t("pages.home.confirm-presence-action") }}</v-btn
           >
         </v-card-actions>
@@ -173,8 +182,15 @@ watch(() => PageMode.value, fetchEvents, { immediate: true });
 const share = async (e: EventInfo) =>
   await shareEvent(e, PageMode.value, authStore);
 
-const confirmPresence = () => {
+const confirmPresence = async (id: number) => {
   console.log("Don't care, didn't ask");
+  try {
+    await currentEventStore.confirmPresence(id);
+    successToast("Welcome to th event");
+    router.push({ name: "participant-view", params: { id } });
+  } catch (e) {
+    errorToast(e);
+  }
 };
 
 const startEvent = async (id: number) => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -126,6 +126,21 @@
       "resend-button-text": "ERNEUT SENDEN",
       "send-button-text": "SENDEN"
     },
+    "participant-event": {
+      "ended-button-link": "",
+      "ended-subtitle": "",
+      "ended-title": "",
+      "not-started-subtitle": "",
+      "not-started-title": "",
+      "ongoing-title": "",
+      "searching-manual-pair-button": "",
+      "searching-minutes-left": "",
+      "searching-subtitle": "",
+      "searching-title": "",
+      "vote-subtitle": "",
+      "vote-title": "",
+      "waiting-title": ""
+    },
     "profile": {
       "delete-button-text": "PROFIL LÖSCHEN",
       "delete-dialog-delete": "LÖSCHEN",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -126,6 +126,21 @@
       "resend-button-text": "RESEND",
       "send-button-text": "SEND"
     },
+    "participant-event": {
+      "ended-button-link": "To Homepage",
+      "ended-subtitle": "This event is now over, thanks for being here!",
+      "ended-title": "That's all volks!",
+      "not-started-subtitle": "Please wait for the organizer to start the event",
+      "not-started-title": "The event hasn't started yet...",
+      "ongoing-title": "Have fun, you two!",
+      "searching-manual-pair-button": "Pair",
+      "searching-minutes-left": "minutes left",
+      "searching-subtitle": "Use the Qr-Scanner below or type their id in the textbox",
+      "searching-title": "Let's find you a partner for this round!",
+      "vote-subtitle": "Your partner will not see your decision immediately",
+      "vote-title": "Did you like them?",
+      "waiting-title": "Waiting for new round"
+    },
     "profile": {
       "delete-button-text": "DELETE PROFILE",
       "delete-dialog-delete": "DELETE",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -11,6 +11,7 @@ import LoginCallbackPage from "../components/pages/LoginCallbackPage.vue";
 import EventPage from "@/components/pages/EventPage.vue";
 import EventSearchPage from "@/components/pages/EventSearchPage.vue";
 import EventDashboard from "@/components/pages/EventDashboard.vue";
+import CurrentParticipantEventPage from "@/components/pages/CurrentParticipantEventPage.vue";
 
 const router = createRouter({
   history: createWebHashHistory(import.meta.env.BASE_URL),
@@ -60,6 +61,12 @@ const router = createRouter({
       path: "/events/:id/dashboard",
       component: EventDashboard,
       name: "dashboard",
+      meta: { requiresLogin: true },
+    },
+    {
+      path: "/events/:id/participant",
+      component: CurrentParticipantEventPage,
+      name: "participant-view",
       meta: { requiresLogin: true },
     },
     {

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -20,7 +20,7 @@ export interface GroupPair {
 
 export interface EventInfo {
   id: number;
-  organizer: string;
+  organizer?: string;
   title: string;
   description: string;
   header_image?: string;

--- a/frontend/src/services/supabase-types.ts
+++ b/frontend/src/services/supabase-types.ts
@@ -723,7 +723,6 @@ export interface paths {
         query: {
           id?: parameters["rowFilter.event_rounds.id"];
           event_id?: parameters["rowFilter.event_rounds.event_id"];
-          break_start_timestamp?: parameters["rowFilter.event_rounds.break_start_timestamp"];
           start_timestamp?: parameters["rowFilter.event_rounds.start_timestamp"];
           end_timestamp?: parameters["rowFilter.event_rounds.end_timestamp"];
           /** Filtering Columns */
@@ -778,7 +777,6 @@ export interface paths {
         query: {
           id?: parameters["rowFilter.event_rounds.id"];
           event_id?: parameters["rowFilter.event_rounds.event_id"];
-          break_start_timestamp?: parameters["rowFilter.event_rounds.break_start_timestamp"];
           start_timestamp?: parameters["rowFilter.event_rounds.start_timestamp"];
           end_timestamp?: parameters["rowFilter.event_rounds.end_timestamp"];
         };
@@ -797,7 +795,6 @@ export interface paths {
         query: {
           id?: parameters["rowFilter.event_rounds.id"];
           event_id?: parameters["rowFilter.event_rounds.event_id"];
-          break_start_timestamp?: parameters["rowFilter.event_rounds.break_start_timestamp"];
           start_timestamp?: parameters["rowFilter.event_rounds.start_timestamp"];
           end_timestamp?: parameters["rowFilter.event_rounds.end_timestamp"];
         };
@@ -1115,7 +1112,7 @@ export interface definitions {
      * @description Note:
      * This is a Foreign Key to `profiles.user_id`.<fk table='profiles' column='user_id'/>
      */
-    organizer: string;
+    organizer?: string;
     /** Format: text */
     title: string;
     /** Format: text */
@@ -1216,7 +1213,11 @@ export interface definitions {
      * This is a Primary Key.<pk/>
      */
     id: number;
-    /** Format: uuid */
+    /**
+     * Format: uuid
+     * @description Note:
+     * This is a Foreign Key to `profiles.user_id`.<fk table='profiles' column='user_id'/>
+     */
     creator: string;
     /** Format: character varying */
     title: string;
@@ -1292,8 +1293,6 @@ export interface definitions {
      */
     event_id: number;
     /** Format: timestamp with time zone */
-    break_start_timestamp: string;
-    /** Format: timestamp with time zone */
     start_timestamp: string;
     /** Format: timestamp with time zone */
     end_timestamp: string;
@@ -1341,9 +1340,17 @@ export interface definitions {
      * This is a Foreign Key to `event_rounds.id`.<fk table='event_rounds' column='id'/>
      */
     event_round: number;
-    /** Format: uuid */
+    /**
+     * Format: uuid
+     * @description Note:
+     * This is a Foreign Key to `profiles.user_id`.<fk table='profiles' column='user_id'/>
+     */
     main_user: string;
-    /** Format: uuid */
+    /**
+     * Format: uuid
+     * @description Note:
+     * This is a Foreign Key to `profiles.user_id`.<fk table='profiles' column='user_id'/>
+     */
     other_user: string;
     /** Format: boolean */
     match?: boolean;
@@ -1482,8 +1489,6 @@ export interface parameters {
   "rowFilter.event_rounds.id": string;
   /** Format: bigint */
   "rowFilter.event_rounds.event_id": string;
-  /** Format: timestamp with time zone */
-  "rowFilter.event_rounds.break_start_timestamp": string;
   /** Format: timestamp with time zone */
   "rowFilter.event_rounds.start_timestamp": string;
   /** Format: timestamp with time zone */

--- a/frontend/src/stores/currentEvent.ts
+++ b/frontend/src/stores/currentEvent.ts
@@ -141,6 +141,16 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     return data;
   }
 
+  async function vote(pairId: number, like: boolean) {
+    const authStore = useAuthStore();
+    if (!authStore.user)
+      throw new Error("User must be logged in to confirm presence");
+    const { error } = await supabase
+      .from("votes")
+      .insert({ user_id: authStore.user.id, user_pair_id: pairId, vote: like });
+    if (error) throw error;
+  }
+
   return {
     hasEvent,
     getCurrentId,
@@ -152,6 +162,7 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     confirmPresence,
     createPair,
     getCurrentPair,
+    vote,
   };
 });
 

--- a/frontend/src/stores/currentEvent.ts
+++ b/frontend/src/stores/currentEvent.ts
@@ -15,8 +15,8 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     return currentEventId.value;
   }
 
-  function setCurrentId(id: number) {
-    currentEventId.value = id.toString();
+  function setCurrentId(id: number | null) {
+    currentEventId.value = id?.toString();
   }
 
   async function getCurrentEvent(): Promise<EventInfo | null> {
@@ -47,6 +47,16 @@ export const useCurrentEventStore = defineStore("current-event", () => {
       throw error;
     }
     setCurrentId(id);
+  }
+
+  async function endCurrentEvent() {
+    if (!currentEventId.value) throw new Error("There is no current event.");
+    const { error } = await supabase
+      .from("events")
+      .update({ is_ended: true })
+      .match({ id: currentEventId.value });
+    if (error) throw error;
+    setCurrentId(null);
   }
 
   async function confirmPresence(id: number) {
@@ -199,6 +209,7 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     getCurrentPair,
     vote,
     getCurrentRoundInfo,
+    endCurrentEvent,
   };
 });
 

--- a/frontend/src/stores/currentEvent.ts
+++ b/frontend/src/stores/currentEvent.ts
@@ -102,6 +102,17 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     return data;
   }
 
+  async function createPair(otherUser: string, eventRound: number) {
+    const authStore = useAuthStore();
+    if (!authStore.user) throw new Error("User is not logged in");
+    const { error } = await supabase.from("event_user_pairs").insert({
+      event_round: eventRound,
+      main_user: authStore.user.id,
+      other_user: otherUser,
+    });
+    if (error) throw error;
+  }
+
   return {
     hasEvent,
     getCurrentId,
@@ -111,6 +122,7 @@ export const useCurrentEventStore = defineStore("current-event", () => {
     getCurrentRound,
     getCurrentEvent,
     confirmPresence,
+    createPair,
   };
 });
 


### PR DESCRIPTION
Additions:

- Realtime participant view page
- Current Event Store
    - Functions to manage the current event
    - Functions to synchronize with the current event

Changes:

- DB-Schema
    - Removed round_break_timestamp from event_rounds because we do not set strict break times anymore
    - Organizer is now optional for events to allow users to delete accounts without deleting their events
- Fixed a broken SQL-Function

_After implementing getCurrentRound and getCurrentPair I decided to create a more complex query to fetch all data required for state at once, but left the individual implementations in, just in case_